### PR TITLE
Add version bump and release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   version:
     name: Bump version from commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,8 +49,8 @@ jobs:
 
   build:
     name: Compile and Build
-    needs: version
-    if: github.event_name != 'push' || !contains(github.event.head_commit.message, 'chore(release):')
+    needs: [version]
+    if: github.ref != 'refs/heads/main' || needs.version.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -82,9 +82,7 @@ jobs:
     name: Build and Publish Docker image
     needs: [build]
     if: |
-      github.event_name == 'push' &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, 'chore(release):')
+      github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,60 @@ on:
     branches: [main]
 
 jobs:
+  version:
+    name: Bump version from commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure Git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Angular dependencies
+        run: npm ci
+        working-directory: angular-app
+
+      - name: Create release commit
+        run: npm run release
+        working-directory: angular-app
+
+      - name: Push release changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git push --follow-tags origin main
+          else
+            echo "No release-worthy commits"
+          fi
+
   build:
     name: Compile and Build
+    needs: version
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Refresh release commit
+        if: needs.version.result == 'success'
+        run: |
+          git fetch origin main
+          git checkout --force origin/main
+          git reset --hard origin/main
 
       - name: Set up Node 20
         uses: actions/setup-node@v4
@@ -32,8 +80,11 @@ jobs:
 
   docker:
     name: Build and Publish Docker image
-    needs: build
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
+    needs: [build]
+    if: |
+      github.event_name == 'push' &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,29 +25,29 @@ jobs:
         run: echo "Not running release workflow here"
 
       - name: Configure Git author
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Node 20
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install Angular dependencies
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: npm ci
         working-directory: angular-app
 
       - name: Create release commit
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: npm run release
         working-directory: angular-app
 
       - name: Push release changes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git push --follow-tags origin main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
 
   build:
     name: Compile and Build
+    needs: [version]
     if: github.ref != 'refs/heads/main' || needs.version.result == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
 
   build:
     name: Compile and Build
-    needs: [version]
     if: github.ref != 'refs/heads/main' || needs.version.result == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
   version:
     name: Bump version from commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,25 +20,34 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Skip release on non-main refs
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+        run: echo "Not running release workflow here"
+
       - name: Configure Git author
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Node 20
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install Angular dependencies
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
         run: npm ci
         working-directory: angular-app
 
       - name: Create release commit
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
         run: npm run release
         working-directory: angular-app
 
       - name: Push release changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git push --follow-tags origin main


### PR DESCRIPTION
Implement a new workflow to automatically bump the version and create a release when changes are pushed to the main branch. This includes steps for checking out the repository, configuring Git, setting up Node.js, installing dependencies, and pushing release changes. Additionally, ensure the build and Docker image publishing jobs depend on the version bump job.